### PR TITLE
KAFKAWRAP-10 - Provide property to set compression type for producer configuration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,2 +1,3 @@
 ## 2021-XX-XX v2.4.0-SNAPSHOT
 * [KAFKAWRAP-2](https://issues.folio.org/browse/KAFKAWRAP-2) Take folio-kafka-wrapper lib out of mod-pubsub repository
+* [KAFKAWRAP-10](https://issues.folio.org/browse/KAFKAWRAP-10) Provide property to set compression type for producer configuration

--- a/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -35,6 +35,9 @@ public class KafkaConfig {
   public static final String KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG = "kafka.consumer.max.poll.interval.ms";
   public static final String KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG_DEFAULT = "300000";
 
+  public static final String KAFKA_PRODUCER_COMPRESSION_TYPE_CONFIG = "kafka.producer.compression.type";
+  public static final String KAFKA_PRODUCER_COMPRESSION_TYPE_CONFIG_DEFAULT = "snappy";
+
   public static final String KAFKA_SECURITY_PROTOCOL_CONFIG = "security.protocol";
   public static final String KAFKA_SECURITY_PROTOCOL_DEFAULT = "PLAINTEXT";
 
@@ -75,6 +78,9 @@ public class KafkaConfig {
     producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
     producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
     producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+    producerProps.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_PRODUCER_COMPRESSION_TYPE_CONFIG, SpringKafkaProperties.KAFKA_PRODUCER_COMPRESSION_TYPE), KAFKA_PRODUCER_COMPRESSION_TYPE_CONFIG_DEFAULT));
+
     if (getMaxRequestSize() > 0) {
       producerProps.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, String.valueOf(getMaxRequestSize()));
     }

--- a/src/main/java/org/folio/kafka/SpringKafkaProperties.java
+++ b/src/main/java/org/folio/kafka/SpringKafkaProperties.java
@@ -12,6 +12,8 @@ public final class SpringKafkaProperties {
 
   public static final String KAFKA_SECURITY_PROTOCOL = "spring.kafka.security.protocol";
 
+  public static final String KAFKA_PRODUCER_COMPRESSION_TYPE = "spring.kafka.producer.compression-type";
+
   public static final String KAFKA_SSL_PROTOCOL = "spring.kafka.ssl.protocol";
 
   public static final String KAFKA_SSL_KEY_PASSWORD = "spring.kafka.ssl.key-password";


### PR DESCRIPTION
## Purpose
since zipping/unzipping operations for data-import payload are going to be deleted it is necessary to provide property to set message compression type for producer configuration

## Approach
* add "kafka.producer.compression.type" property to the KafkaConfig with `"snappy"` compression codec by default


## Learning
[KAFKAWRAP-10](https://issues.folio.org/browse/KAFKAWRAP-10)
