### PR TITLE
KAFKAWRAP-11 Remove duplicate kafka headers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,4 @@
 ## 2021-XX-XX v2.4.0-SNAPSHOT
 * [KAFKAWRAP-2](https://issues.folio.org/browse/KAFKAWRAP-2) Take folio-kafka-wrapper lib out of mod-pubsub repository
 * [KAFKAWRAP-10](https://issues.folio.org/browse/KAFKAWRAP-10) Provide property to set compression type for producer configuration
+* [KAFKAWRAP-11](https://issues.folio.org/browse/KAFKAWRAP-11) Remove duplicate kafka headers

--- a/src/main/java/org/folio/kafka/KafkaHeaderUtils.java
+++ b/src/main/java/org/folio/kafka/KafkaHeaderUtils.java
@@ -5,10 +5,10 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.kafka.client.producer.KafkaHeader;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -54,7 +54,7 @@ public class KafkaHeaderUtils {
    * @return returns a predicate that maintains state about what it's seen previously, and that returns whether the given element was seen for the first time
    */
   private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
-    Set<Object> seen = ConcurrentHashMap.newKeySet();
+    Set<Object> seen = new HashSet<>();
     return t -> seen.add(keyExtractor.apply(t));
   }
 

--- a/src/main/java/org/folio/kafka/KafkaHeaderUtils.java
+++ b/src/main/java/org/folio/kafka/KafkaHeaderUtils.java
@@ -7,6 +7,10 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class KafkaHeaderUtils {
@@ -27,6 +31,7 @@ public class KafkaHeaderUtils {
       .entries()
       .stream()
       .map(e -> KafkaHeader.header(e.getKey(), e.getValue()))
+      .filter(distinctByKey(KafkaHeader::key))
       .collect(Collectors.toList());
   }
 
@@ -40,6 +45,17 @@ public class KafkaHeaderUtils {
             return value == null ? "" : value.toString();
           },
           (a, b) -> StringUtils.isNotBlank(a) ? a : b)));
+  }
+
+  /**
+   * Retrieve distinct value by key
+   *
+   * @param keyExtractor function to get a key
+   * @return returns a predicate that maintains state about what it's seen previously, and that returns whether the given element was seen for the first time
+   */
+  private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
+    Set<Object> seen = ConcurrentHashMap.newKeySet();
+    return t -> seen.add(keyExtractor.apply(t));
   }
 
 }

--- a/src/test/java/org/folio/kafka/KafkaHeaderUtilsTest.java
+++ b/src/test/java/org/folio/kafka/KafkaHeaderUtilsTest.java
@@ -1,0 +1,22 @@
+package org.folio.kafka;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import io.vertx.kafka.client.producer.KafkaHeader;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class KafkaHeaderUtilsTest {
+
+  @Test
+  public void shouldReturnDistinctValuesInListWhenThereAreDuplicateElements() {
+    MultiMap headers = new HeadersMultiMap();
+    headers.add("x-okapi-request-method", "POST");
+    headers.add("x-okapi-request-method", "POST");
+    List<KafkaHeader> kafkaHeaders = KafkaHeaderUtils.kafkaHeadersFromMultiMap(headers);
+    assertEquals(1, kafkaHeaders.size());
+  }
+}


### PR DESCRIPTION
## Purpose
List<KafkaHeader> kafkaHeaders have to contain only unique values.

## Approach
Created distinctByKey method that adds filter for kafkaHeadersFromMultiMap to avoid kafka headers duplication.

## Learning
[KAFKAWRAP-11](https://issues.folio.org/browse/KAFKAWRAP-11)