### PR TITLE
KAFKAWRAP-14 Fix Log4j vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.13.3</version>
+      <version>2.15.0</version>
     </dependency>
     <dependency>
       <groupId>io.kcache</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   </licenses>
 
   <properties>
-    <vertx.version>4.0.0</vertx.version>
+    <vertx.version>4.1.2</vertx.version>
     <junit.version>4.13.1</junit.version>
     <lombok.version>1.18.12</lombok.version>
     <commons-lang3.version>3.10</commons-lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.15.0</version>
+      <version>2.16.0</version>
     </dependency>
     <dependency>
       <groupId>io.kcache</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   </licenses>
 
   <properties>
-    <vertx.version>4.1.2</vertx.version>
+    <vertx.version>4.2.1</vertx.version>
     <junit.version>4.13.1</junit.version>
     <lombok.version>1.18.12</lombok.version>
     <commons-lang3.version>3.10</commons-lang3.version>


### PR DESCRIPTION
This PR relates only to LOTUS release (for previous releases changes were made directly in release branches and did not include any upgrades apart from log4j dependency)

Upgrade log4j dependency to v2.16.0
Vertx to 4.2.1 