### PR TITLE
Improve logging for handling duplicate events to not write in logs full stack trace

### DIFF
--- a/src/main/java/org/folio/kafka/exception/DuplicateEventException.java
+++ b/src/main/java/org/folio/kafka/exception/DuplicateEventException.java
@@ -1,0 +1,7 @@
+package org.folio.kafka.exception;
+
+public class DuplicateEventException extends RuntimeException {
+  public DuplicateEventException(String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
## Purpose
Prevent logging of full stack traces for duplicate event to not confuse that someting was wrong

**Example of such stack trace:**
10:01:36.749 [vert.x-worker-thread-0] ERROR KafkaConsumerWrapper [138548eqId] Error while processing a record - id: 81 subscriptionPattern: SubscriptionDefinition(eventType=DI_PARSED_RECORDS_CHUNK_SAVED, subscriptionPattern=FOLIO\.Default\.\w{1,}\.DI_PARSED_RECORDS_CHUNK_SAVED) offset: 2 org.folio.dataimport.util.exception.ConflictException: Event with eventId=4013eb1c-83ce-4782-b6d7-bbda4a4323e3 for handlerId=4d39ced7-9b67-4bdc-b232-343dbb5b8cef is already processed. at org.folio.services.EventProcessedServiceImpl.lambda$collectData$0(EventProcessedServiceImpl.java:28) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.Composition.onFailure(Composition.java:50) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureBase.emitFailure(FutureBase.java:75) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureImpl.tryFail(FutureImpl.java:230) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.PromiseImpl.tryFail(PromiseImpl.java:23) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.PromiseImpl.onFailure(PromiseImpl.java:54) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureBase.emitFailure(FutureBase.java:75) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureImpl.tryFail(FutureImpl.java:230) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.Composition$1.onFailure(Composition.java:66) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureImpl$ListenerArray.onFailure(FutureImpl.java:268) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureBase.emitFailure(FutureBase.java:75) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureImpl.tryFail(FutureImpl.java:230) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.PromiseImpl.tryFail(PromiseImpl.java:23) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.sqlclient.impl.QueryResultBuilder.tryFail(QueryResultBuilder.java:118) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.Promise.fail(Promise.java:89) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.Promise.handle(Promise.java:53) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.Promise.handle(Promise.java:29) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureImpl$3.onFailure(FutureImpl.java:153) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureBase.lambda$emitFailure$1(FutureBase.java:69) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.WorkerContext.lambda$execute$2(WorkerContext.java:104) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76) ~[mod-source-record-manager-server-fat.jar:?] at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?] at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?] at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [mod-source-record-manager-server-fat.jar:?] at java.lang.Thread.run(Thread.java:829) [?:?]

## Approach
Using instanceof to check exception type and log accordingly