### PR TITLE
KAFKAWRAP-19 - events_cache topic needs to have a prefix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2022-02-xx v2.4.3
+* [KAFKAWRAP-19](https://issues.folio.org/browse/KAFKAWRAP-19) Expand kafka cache topic name with env id prefix
+
 ## 2021-12-21 v2.4.2
 * Update log4j to v2.17.0
 

--- a/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -4,6 +4,7 @@ import io.kcache.KafkaCacheConfig;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -108,9 +109,14 @@ public class KafkaConfig {
   }
 
   public KafkaCacheConfig getCacheConfig() {
+    String topicName = SimpleConfigurationReader.getValue(KAFKA_CACHE_TOPIC_PROPERTY, KAFKA_CACHE_TOPIC_PROPERTY_DEFAULT);
+    if (StringUtils.isNotBlank(envId)) {
+      topicName = String.format("%s.%s", envId, topicName);
+    }
+
     Properties props = new Properties();
     props.put(KafkaCacheConfig.KAFKACACHE_BOOTSTRAP_SERVERS_CONFIG, "PLAINTEXT://" + getKafkaUrl()); //It should be as PLAINTEXT, as known issue in Kafka.
-    props.put(KAFKA_CACHE_TOPIC_PROPERTY, SimpleConfigurationReader.getValue(KAFKA_CACHE_TOPIC_PROPERTY, KAFKA_CACHE_TOPIC_PROPERTY_DEFAULT));
+    props.put(KAFKA_CACHE_TOPIC_PROPERTY, topicName);
     props.put(KAFKACACHE_TOPIC_REQUIRE_COMPACT_CONFIG, false);
     return new KafkaCacheConfig(props);
   }


### PR DESCRIPTION
## Purpose
Kafka cluster is shared between different environments, it is necessary to define separate kafka cache topic for each environment

## Approach
* add end id prefix to kafka cache topic name


## Learning
[KAFKAWRAP-19](https://issues.folio.org/browse/KAFKAWRAP-19)
