### PR TITLE
KAFKAWRAP-18. Add implementation of demand() method to support DI flow control

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2022-xx-xx v2.6.0-SNAPSHOT
+* [KAFKAWRAP-18](https://issues.folio.org/browse/KAFKAWRAP-18) Add implementation pause/resume methods to support DI flow control
+
 ## 2022-02-22 v2.5.0
 * [KAFKAWRAP-3](https://issues.folio.org/browse/KAFKAWRAP-3) Implement error handler contract for KafkaConsumerWrapper
 * [MODDATAIMP-623](https://issues.folio.org/browse/MODDATAIMP-623) Remove Kafka cache initialization and Maven dependency

--- a/src/main/java/org/folio/kafka/KafkaConsumerWrapper.java
+++ b/src/main/java/org/folio/kafka/KafkaConsumerWrapper.java
@@ -130,6 +130,14 @@ public class KafkaConsumerWrapper<K, V> implements Handler<KafkaConsumerRecord<K
     return startPromise.future();
   }
 
+  public void pause() {
+    kafkaConsumer.pause();
+  }
+
+  public void resume() {
+    kafkaConsumer.resume();
+  }
+
   public Future<Void> stop() {
     Promise<Void> stopPromise = Promise.promise();
     kafkaConsumer.unsubscribe(uar -> {
@@ -162,7 +170,7 @@ public class KafkaConsumerWrapper<K, V> implements Handler<KafkaConsumerRecord<K
       int requestNo = pauseRequests.getAndIncrement();
       LOGGER.debug("Threshold is exceeded, preparing to pause, globalLoad: {}, currentLoad: {}, requestNo: {}", globalLoad, currentLoad, requestNo);
       if (requestNo == 0) {
-        kafkaConsumer.pause();
+        pause();
         LOGGER.info("Consumer - id: {} subscriptionPattern: {} kafkaConsumer.pause() requested" + " currentLoad: {}, loadLimit: {}", id, subscriptionDefinition, currentLoad, loadLimit);
       }
     }
@@ -217,7 +225,7 @@ public class KafkaConsumerWrapper<K, V> implements Handler<KafkaConsumerRecord<K
           LOGGER.debug("Threshold is exceeded, preparing to resume, globalLoad: {}, currentLoad: {}, requestNo: {}", globalLoad, actualCurrentLoad, requestNo);
           if (requestNo == 0) {
 //           synchronized (this) { all this is handled within the same verticle
-            kafkaConsumer.resume();
+            resume();
             LOGGER.info("Consumer - id: {} subscriptionPattern: {} kafkaConsumer.resume() requested currentLoad: {} loadBottomGreenLine: {}", id, subscriptionDefinition, actualCurrentLoad, loadBottomGreenLine);
 //            }
           }

--- a/src/main/java/org/folio/kafka/KafkaConsumerWrapper.java
+++ b/src/main/java/org/folio/kafka/KafkaConsumerWrapper.java
@@ -130,12 +130,27 @@ public class KafkaConsumerWrapper<K, V> implements Handler<KafkaConsumerRecord<K
     return startPromise.future();
   }
 
+  /**
+   * Pauses kafka consumer.
+   */
   public void pause() {
     kafkaConsumer.pause();
   }
 
+  /**
+   * Resumes kafka consumer.
+   */
   public void resume() {
     kafkaConsumer.resume();
+  }
+
+  /**
+   * Gets usage demand to determine if consumer paused.
+   *
+   * @return 0 if consumer paused, otherwise any value greater than 0 would mean that consumer working.
+   */
+  public long demand() {
+    return kafkaConsumer.demand();
   }
 
   public Future<Void> stop() {

--- a/src/main/java/org/folio/kafka/KafkaConsumerWrapper.java
+++ b/src/main/java/org/folio/kafka/KafkaConsumerWrapper.java
@@ -29,7 +29,7 @@ public class KafkaConsumerWrapper<K, V> implements Handler<KafkaConsumerRecord<K
 
   public static final int GLOBAL_SENSOR_NA = -1;
 
-  private final static AtomicInteger indexer = new AtomicInteger();
+  private static final AtomicInteger indexer = new AtomicInteger();
 
   private final int id = indexer.getAndIncrement();
 
@@ -224,10 +224,8 @@ public class KafkaConsumerWrapper<K, V> implements Handler<KafkaConsumerRecord<K
           int requestNo = pauseRequests.decrementAndGet();
           LOGGER.debug("Threshold is exceeded, preparing to resume, globalLoad: {}, currentLoad: {}, requestNo: {}", globalLoad, actualCurrentLoad, requestNo);
           if (requestNo == 0) {
-//           synchronized (this) { all this is handled within the same verticle
             resume();
             LOGGER.info("Consumer - id: {} subscriptionPattern: {} kafkaConsumer.resume() requested currentLoad: {} loadBottomGreenLine: {}", id, subscriptionDefinition, actualCurrentLoad, loadBottomGreenLine);
-//            }
           }
         }
       }


### PR DESCRIPTION
demand() needed to gets usage demand to determine if consumer paused.
Return 0 if consumer paused, otherwise any value greater than 0 would mean that consumer working.
This change needed to support DI flow control logic.