### PR TITLE
KAFKAWRAP-22: Upgrade vulns: log4j-core, jackson-databind, netty-codec-http

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
   </licenses>
 
   <properties>
-    <vertx.version>4.2.1</vertx.version>
-    <junit.version>4.13.1</junit.version>
+    <vertx.version>4.2.7</vertx.version>
+    <junit.version>4.13.2</junit.version>
     <lombok.version>1.18.12</lombok.version>
     <commons-lang3.version>3.10</commons-lang3.version>
     <sonar.exclusions>**/org/folio/kafka/SpringKafkaProperties.java</sonar.exclusions>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.17.0</version>
+      <version>2.17.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Upgrade Vert.x from 4.2.1 to 4.2.7.

The Vert.x upgrade indirectly upgrades jackson-databind from 2.11.4 to 2.13.2.1 fixing Denial of Service (DoS): https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-36518

The Vert.x upgrade indirectly upgrades netty-codec-http from 4.1.69.Final to 4.1.74.Final fixing HTTP Request Smuggling https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-43797

Upgrade log4j-core from 2.17.0 to 2.17.2 fixing https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-44832