### PR TITLE
KAFKAWRAP-25: Upgrade dependencies fixing vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,10 +16,9 @@
   </licenses>
 
   <properties>
-    <vertx.version>4.2.7</vertx.version>
     <junit.version>4.13.2</junit.version>
-    <lombok.version>1.18.12</lombok.version>
-    <commons-lang3.version>3.10</commons-lang3.version>
+    <lombok.version>1.18.24</lombok.version>
+    <commons-lang3.version>3.12.0</commons-lang3.version>
     <sonar.exclusions>**/org/folio/kafka/SpringKafkaProperties.java</sonar.exclusions>
   </properties>
 
@@ -31,11 +30,22 @@
     </repository>
   </repositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>4.3.4</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-kafka-client</artifactId>
-      <version>${vertx.version}</version>
       <exclusions>
         <exclusion>
           <groupId>net.sf.jopt-simple</groupId>
@@ -65,7 +75,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.17.2</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -76,19 +86,18 @@
     <dependency>
       <groupId>net.mguenther.kafka</groupId>
       <artifactId>kafka-junit</artifactId>
-      <version>2.6.0</version>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>${vertx.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.2.0</version>
+      <version>4.8.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -111,7 +120,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.10.1</version>
         <configuration>
           <release>11</release>
           <encoding>UTF-8</encoding>
@@ -124,7 +133,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
+        <version>2.22.2</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
@@ -133,7 +142,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.4</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/src/test/java/org/folio/kafka/KafkaConsumerWrapperTest.java
+++ b/src/test/java/org/folio/kafka/KafkaConsumerWrapperTest.java
@@ -13,8 +13,8 @@ import net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig;
 import net.mguenther.kafka.junit.KeyValue;
 import net.mguenther.kafka.junit.SendKeyValues;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -23,8 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
-
 import static java.lang.String.format;
 import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
 import static org.folio.kafka.KafkaConfig.KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG;
@@ -38,18 +36,20 @@ import static org.mockito.Mockito.verify;
 public class KafkaConsumerWrapperTest {
 
   private static final String EVENT_TYPE = "test_topic";
+  private static final String EVENT_TYPE2 = "test_topic2";
   private static final String KAFKA_ENV = "test-env";
   private static final String TENANT_ID = "diku";
   private static final String MODULE_NAME = "test_module";
 
-  @Rule
-  public EmbeddedKafkaCluster kafkaCluster = provisionWith(EmbeddedKafkaClusterConfig.useDefaults());
   private Vertx vertx = Vertx.vertx();
+  private EmbeddedKafkaCluster kafkaCluster;
   private KafkaConfig kafkaConfig;
   private KafkaAdminClient kafkaAdminClient;
 
   @Before
   public void setUp() {
+    kafkaCluster = provisionWith(EmbeddedKafkaClusterConfig.defaultClusterConfig());
+    kafkaCluster.start();
     String[] hostAndPort = kafkaCluster.getBrokerList().split(":");
     kafkaConfig = KafkaConfig.builder()
       .kafkaHost(hostAndPort[0])
@@ -57,6 +57,12 @@ public class KafkaConsumerWrapperTest {
       .build();
 
     kafkaAdminClient = KafkaAdminClient.create(vertx, Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaConfig.getKafkaUrl()));
+  }
+
+  @After
+  public void tearDown(TestContext testContext) {
+    kafkaAdminClient.close().onComplete(testContext.asyncAssertSuccess());
+    kafkaCluster.close();
   }
 
   @Test
@@ -164,10 +170,9 @@ public class KafkaConsumerWrapperTest {
   }
 
   @Test
-  public void shouldReturnSucceededFutureAndUnsubscribeWhenStopIsCalled(TestContext testContext) {
-    Async async = testContext.async();
-    SubscriptionDefinition subscriptionDefinition = KafkaTopicNameHelper.createSubscriptionDefinition(KAFKA_ENV, getDefaultNameSpace(), EVENT_TYPE);
-    String groupId = KafkaTopicNameHelper.formatGroupName(EVENT_TYPE, MODULE_NAME);
+  public void shouldReturnSucceededFutureAndUnsubscribeWhenStopIsCalled(TestContext testContext) throws Exception {
+    SubscriptionDefinition subscriptionDefinition = KafkaTopicNameHelper.createSubscriptionDefinition(KAFKA_ENV, getDefaultNameSpace(), EVENT_TYPE2);
+    String groupId = KafkaTopicNameHelper.formatGroupName(EVENT_TYPE2, MODULE_NAME);
 
     KafkaConsumerWrapper<String, String> kafkaConsumerWrapper = KafkaConsumerWrapper.<String, String>builder()
       .context(vertx.getOrCreateContext())
@@ -178,20 +183,12 @@ public class KafkaConsumerWrapperTest {
       .subscriptionDefinition(subscriptionDefinition)
       .build();
 
-    Future<Void> stopFuture = kafkaConsumerWrapper
-      .start(record -> Future.succeededFuture(), MODULE_NAME)
-      // wait for joining to group
-      .compose(v -> runWithDelay(1000, () -> kafkaAdminClient.describeConsumerGroups(List.of(groupId))))
-      .onComplete(ar -> testContext.assertTrue(ar.succeeded()))
-      .onSuccess(groups -> testContext.assertEquals(1, groups.get(groupId).getMembers().size()))
-      .compose(v -> kafkaConsumerWrapper.stop());
-
-    stopFuture.compose(v -> kafkaAdminClient.describeConsumerGroups(List.of(groupId)))
-      .onComplete(ar -> {
-        testContext.assertTrue(ar.succeeded());
-        testContext.assertEquals(0, ar.result().get(groupId).getMembers().size());
-        async.complete();
-      });
+    awaitMembersSize(groupId, 0)
+    .compose(v -> kafkaConsumerWrapper.start(record -> Future.succeededFuture(), MODULE_NAME))
+    .compose(v -> awaitMembersSize(groupId, 1))
+    .compose(v -> kafkaConsumerWrapper.stop())
+    .compose(v -> awaitMembersSize(groupId, 0))
+    .onComplete(testContext.asyncAssertSuccess());
   }
 
   @Test
@@ -234,10 +231,13 @@ public class KafkaConsumerWrapperTest {
     }
   }
 
-  private <T> Future<T> runWithDelay(long delay, Supplier<Future<T>> task) {
-    Promise<T> promise = Promise.promise();
-    vertx.setTimer(delay, id -> task.get().onComplete(promise));
-    return promise.future();
+  private Future<Void> awaitMembersSize(String groupId, int expectedSize) {
+    return kafkaAdminClient.describeConsumerGroups(List.of(groupId))
+        .compose(groups -> {
+          if (groups.get(groupId).getMembers().size() == expectedSize) {
+            return Future.succeededFuture();
+          }
+          return awaitMembersSize(groupId, expectedSize);
+        });
   }
-
 }


### PR DESCRIPTION
Upgrading Vert.x from 4.2.7 to 4.3.4.

The Vert.x upgrade indirectly upgrades jackson-databind from 2.13.2.1 to 2.13.4 fixing Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2022-42004

The Vert.x upgrade indirectly upgrades kafka-clients from 2.6.3 to 3.0.2 fixing a Timing Attack https://nvd.nist.gov/vuln/detail/CVE-2021-38153

The Vert.x upgrade indirectly upgrades netty-common from 4.1.74.Final to 4.1.82.Final fixing Information Exposure https://nvd.nist.gov/vuln/detail/CVE-2022-24823

Upgrading all other dependencies to the latest release version.

KafkaConsumerWrapperTest was changed to avoid test interdependencies and to better handle Kafka latencies (eventual consistency).

To match the Vert.x kafka version kafka-junit was upgraded from 2.6.0 to 3.0.1 with a breaking change in junit.EmbeddedKafkaCluster causing a code change in KafkaConsumerWrapperTest.