### PR TITLE
KAFKAWRAP-38 add tenant identifying header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>folio-kafka-wrapper</artifactId>
-  <version>2.8.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>folio-kafka-wrapper</name>
 

--- a/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -7,6 +7,7 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.SslConfigs;
+import org.folio.kafka.interceptors.TenantIdCheckInterceptor;
 
 import java.util.HashMap;
 import java.util.List;
@@ -89,6 +90,7 @@ public class KafkaConfig {
     producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
     producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
     producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+    producerProps.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, TenantIdCheckInterceptor.class.getName());
     producerProps.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, SimpleConfigurationReader.getValue(
       List.of(KAFKA_PRODUCER_COMPRESSION_TYPE_CONFIG, SpringKafkaProperties.KAFKA_PRODUCER_COMPRESSION_TYPE), KAFKA_PRODUCER_COMPRESSION_TYPE_CONFIG_DEFAULT));
 

--- a/src/main/java/org/folio/kafka/headers/FolioKafkaHeaders.java
+++ b/src/main/java/org/folio/kafka/headers/FolioKafkaHeaders.java
@@ -1,0 +1,5 @@
+package org.folio.kafka.headers;
+
+public class FolioKafkaHeaders {
+  public static final String TENANT_ID = "folio.tenantId";
+}

--- a/src/main/java/org/folio/kafka/interceptors/TenantIdCheckInterceptor.java
+++ b/src/main/java/org/folio/kafka/interceptors/TenantIdCheckInterceptor.java
@@ -19,8 +19,8 @@ public class TenantIdCheckInterceptor implements ProducerInterceptor<String, Str
 
   private static final Logger LOGGER = LogManager.getLogger();
 
-  public static final String TENANT_ID_ERROR_MESSAGE = "Kafka record does not have a tenant identifying header. " +
-    "Use KafkaProducerRecordBuilder to build the record";
+  protected static final String TENANT_ID_ERROR_MESSAGE = "Kafka record does not have a tenant identifying header. " +
+    "Use KafkaProducerRecordBuilder to build the record. TopicName=";
   @Override
   public ProducerRecord<String, String> onSend(ProducerRecord<String, String> record) {
     Headers headers = record.headers();
@@ -31,7 +31,7 @@ public class TenantIdCheckInterceptor implements ProducerInterceptor<String, Str
       }
     }
     if (!isTenantIdHeaderExist) {
-      LOGGER.error(TENANT_ID_ERROR_MESSAGE);
+      LOGGER.error(TENANT_ID_ERROR_MESSAGE + record.topic());
     }
 
     return record;

--- a/src/main/java/org/folio/kafka/interceptors/TenantIdCheckInterceptor.java
+++ b/src/main/java/org/folio/kafka/interceptors/TenantIdCheckInterceptor.java
@@ -28,6 +28,7 @@ public class TenantIdCheckInterceptor implements ProducerInterceptor<String, Str
     for (Header header : headers) {
       if (header.key().equals(TENANT_ID)) {
         isTenantIdHeaderExist = true;
+        break;
       }
     }
     if (!isTenantIdHeaderExist) {

--- a/src/main/java/org/folio/kafka/interceptors/TenantIdCheckInterceptor.java
+++ b/src/main/java/org/folio/kafka/interceptors/TenantIdCheckInterceptor.java
@@ -20,7 +20,7 @@ public class TenantIdCheckInterceptor implements ProducerInterceptor<String, Str
   private static final Logger LOGGER = LogManager.getLogger();
 
   protected static final String TENANT_ID_ERROR_MESSAGE = "Kafka record does not have a tenant identifying header. " +
-    "Use KafkaProducerRecordBuilder to build the record. TopicName=";
+    "Use KafkaProducerRecordBuilder to build the record. TopicName={}";
   @Override
   public ProducerRecord<String, String> onSend(ProducerRecord<String, String> record) {
     Headers headers = record.headers();
@@ -31,7 +31,7 @@ public class TenantIdCheckInterceptor implements ProducerInterceptor<String, Str
       }
     }
     if (!isTenantIdHeaderExist) {
-      LOGGER.error(TENANT_ID_ERROR_MESSAGE + record.topic());
+      LOGGER.error(TENANT_ID_ERROR_MESSAGE, record.topic());
     }
 
     return record;

--- a/src/main/java/org/folio/kafka/interceptors/TenantIdCheckInterceptor.java
+++ b/src/main/java/org/folio/kafka/interceptors/TenantIdCheckInterceptor.java
@@ -1,0 +1,54 @@
+package org.folio.kafka.interceptors;
+
+import org.apache.kafka.clients.producer.ProducerInterceptor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import static org.folio.kafka.headers.FolioKafkaHeaders.TENANT_ID;
+
+import java.util.Map;
+
+/**
+ * Kafka producer interceptor that will check the presence of a tenant Id header and log an error
+ */
+public class TenantIdCheckInterceptor implements ProducerInterceptor<String, String> {
+
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  public static final String TENANT_ID_ERROR_MESSAGE = "Kafka record does not have a tenant identifying header. " +
+    "Use KafkaProducerRecordBuilder to build the record";
+  @Override
+  public ProducerRecord<String, String> onSend(ProducerRecord<String, String> record) {
+    Headers headers = record.headers();
+    boolean isTenantIdHeaderExist = false;
+    for (Header header : headers) {
+      if (header.key().equals(TENANT_ID)) {
+        isTenantIdHeaderExist = true;
+      }
+    }
+    if (!isTenantIdHeaderExist) {
+      LOGGER.error(TENANT_ID_ERROR_MESSAGE);
+    }
+
+    return record;
+  }
+
+  @Override
+  public void onAcknowledgement(RecordMetadata metadata, Exception exception) {
+
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+
+  }
+}

--- a/src/main/java/org/folio/kafka/services/KafkaProducerRecordBuilder.java
+++ b/src/main/java/org/folio/kafka/services/KafkaProducerRecordBuilder.java
@@ -11,6 +11,7 @@ import java.util.Set;
 
 import static io.vertx.kafka.client.producer.KafkaProducerRecord.create;
 import static java.util.Objects.isNull;
+import static org.folio.kafka.headers.FolioKafkaHeaders.TENANT_ID;
 import static org.folio.okapi.common.XOkapiHeaders.TENANT;
 import static org.folio.okapi.common.XOkapiHeaders.URL;
 
@@ -18,6 +19,7 @@ public final class KafkaProducerRecordBuilder<K, V> {
   private static final Set<String> FORWARDER_HEADERS = Set.of(URL.toLowerCase(), TENANT.toLowerCase());
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
+  private String tenantId;
   private V value;
   private K key;
   private String topic;
@@ -25,6 +27,10 @@ public final class KafkaProducerRecordBuilder<K, V> {
 
   static {
     MAPPER.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+  }
+
+  public KafkaProducerRecordBuilder(String tenantId) {
+    this.tenantId = tenantId;
   }
 
   public KafkaProducerRecordBuilder<K, V> value(V value) {
@@ -57,10 +63,12 @@ public final class KafkaProducerRecordBuilder<K, V> {
 
   public KafkaProducerRecord<K, String> build() {
     try {
-      if (isNull(value)) throw new NullPointerException();
+      if (isNull(value)) throw new NullPointerException("value cannot be set to null");
+      if (isNull(tenantId)) throw new NullPointerException("tenantId cannot be set to null");
       var valueAsString = MAPPER.writeValueAsString(this.value);
 
       var kafkaProducerRecord = create(topic, key, valueAsString);
+      kafkaProducerRecord.addHeader(TENANT_ID, tenantId);
       headers.forEach(kafkaProducerRecord::addHeader);
 
       return kafkaProducerRecord;

--- a/src/test/java/org/folio/kafka/KafkaConfigTest.java
+++ b/src/test/java/org/folio/kafka/KafkaConfigTest.java
@@ -2,6 +2,7 @@ package org.folio.kafka;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.folio.kafka.interceptors.TenantIdCheckInterceptor;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -53,5 +54,18 @@ public class KafkaConfigTest {
 
       Assert.assertEquals(5, kafkaConfig.getNumberOfPartitions());
     }
+
+  @Test
+  public void shouldHaveTenantIdInterceptorSet() {
+    KafkaConfig kafkaConfig = KafkaConfig.builder()
+      .kafkaHost("127.0.0.1")
+      .kafkaPort("9092")
+      .build();
+
+    Map<String, String> producerProps = kafkaConfig.getProducerProps();
+
+    Assert.assertEquals(TenantIdCheckInterceptor.class.getName(),
+      producerProps.getOrDefault(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, ""));
+  }
 
 }

--- a/src/test/java/org/folio/kafka/SimpleKafkaProducerManagerTest.java
+++ b/src/test/java/org/folio/kafka/SimpleKafkaProducerManagerTest.java
@@ -1,6 +1,7 @@
 package org.folio.kafka;
 
 import io.vertx.core.Vertx;
+import io.vertx.kafka.client.producer.KafkaHeader;
 import org.folio.kafka.exception.ProducerCreationException;
 import org.folio.kafka.services.KafkaProducerRecordBuilder;
 import org.junit.Test;
@@ -8,9 +9,11 @@ import org.junit.Test;
 import java.util.Map;
 
 import static java.util.UUID.randomUUID;
+import static org.folio.kafka.headers.FolioKafkaHeaders.TENANT_ID;
 import static org.folio.kafka.services.TestKafkaTopic.TOPIC_ONE;
 import static org.folio.okapi.common.XOkapiHeaders.TENANT;
 import static org.folio.okapi.common.XOkapiHeaders.URL;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -31,7 +34,7 @@ public class SimpleKafkaProducerManagerTest {
   public void shouldBuildKafkaProducerRecord() {
     var expectedKey = randomUUID().toString();
     var expectedHeader = "okapi-header";
-    var producerRecord = new KafkaProducerRecordBuilder<String, String>()
+    var producerRecord = new KafkaProducerRecordBuilder<String, String>("tenant")
       .topic(TOPIC_ONE.topicName())
       .value(TOPIC_ONE.topicName())
       .key(expectedKey)
@@ -39,30 +42,38 @@ public class SimpleKafkaProducerManagerTest {
       .build();
 
     assertEquals(producerRecord.topic(), TOPIC_ONE.topicName());
-    assertEquals(producerRecord.headers().get(0).key(), expectedHeader);
+    assertArrayEquals(new String[]{TENANT_ID, expectedHeader},producerRecord.headers().stream().map(KafkaHeader::key).toArray());
     assertEquals(producerRecord.key(), expectedKey);
     assertNotNull(producerRecord.value());
   }
 
   @Test
   public void shouldPropagateOkapiHeaders() {
+    String tenantId = "2";
     Map<String, String> okapiHeaders = Map.of(
       URL.toLowerCase(), "1",
-      TENANT.toLowerCase(), "2",
+      TENANT.toLowerCase(), tenantId,
       "not-okapi", "3");
 
-    var producerRecord = new KafkaProducerRecordBuilder<String, String>()
+    var producerRecord = new KafkaProducerRecordBuilder<String, String>(tenantId)
       .propagateOkapiHeaders(okapiHeaders)
       .value(TOPIC_ONE.topicName())
       .build();
 
-    assertEquals(2, producerRecord.headers().size());
+    assertEquals(3, producerRecord.headers().size());
   }
 
   @Test(expected = ProducerCreationException.class)
   public void shouldFailToBuildNullValue() {
-    new KafkaProducerRecordBuilder<String, String>()
+    new KafkaProducerRecordBuilder<String, String>("tenant")
       .value(null)
+      .build();
+  }
+
+  @Test(expected = ProducerCreationException.class)
+  public void shouldFailToBuildNullTenant() {
+    new KafkaProducerRecordBuilder<String, String>(null)
+      .value("test")
       .build();
   }
 }

--- a/src/test/java/org/folio/kafka/interceptors/TenantIdCheckInterceptorTest.java
+++ b/src/test/java/org/folio/kafka/interceptors/TenantIdCheckInterceptorTest.java
@@ -1,12 +1,15 @@
 package org.folio.kafka.interceptors;
 
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.folio.kafka.services.KafkaProducerRecordBuilder;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.helpers.MessageFormatter;
 
@@ -14,6 +17,49 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TenantIdCheckInterceptorTest {
+
+  private static TestAppender appender;
+
+  @BeforeClass
+  public static void classSetup() {
+    Logger logger = LogManager.getLogger(TenantIdCheckInterceptor.class.getName());
+    appender = new TestAppender("TestAppender", null);
+    ((LoggerContext) LogManager.getContext(false)).getConfiguration().addAppender(appender);
+    ((org.apache.logging.log4j.core.Logger) logger).addAppender(appender);
+    appender.start();
+  }
+
+  @Test
+  public void onSend() {
+    String topicName = "topicName";
+    String key = "key-0";
+    String value = "value-0";
+    //
+    // create a record with no headers, message should be logged
+    ProducerRecord<String, String> kafkaRecord = new ProducerRecord<>(topicName, 0, key, value);
+    TenantIdCheckInterceptor tenantIdCheckInterceptor = new TenantIdCheckInterceptor();
+
+    tenantIdCheckInterceptor.onSend(kafkaRecord);
+
+    Assert.assertEquals(1, appender.getMessages().size());
+    Assert.assertEquals(MessageFormatter.format(TenantIdCheckInterceptor.TENANT_ID_ERROR_MESSAGE, topicName).getMessage()
+      , appender.getMessages().get(0));
+
+    // clear logged messages
+    appender.clear();
+
+    //
+    // create record with necessary headers, message should not be logged
+    KafkaProducerRecord<String, String> vertxRecord = new KafkaProducerRecordBuilder<String, String>("tenant")
+      .topic(topicName)
+      .key(key)
+      .value(value)
+      .build();
+
+    tenantIdCheckInterceptor.onSend(vertxRecord.record());
+
+    Assert.assertEquals(0, appender.getMessages().size());
+  }
 
   private static class TestAppender extends AbstractAppender {
 
@@ -31,24 +77,10 @@ public class TenantIdCheckInterceptorTest {
     List<String> getMessages() {
       return messages;
     }
+
+    void clear() {
+      messages.clear();
+    }
   }
 
-  @Test
-  public void onSend() {
-    // get logger belonging to the class and add test appender
-    Logger logger = LogManager.getLogger(TenantIdCheckInterceptor.class.getName());
-    TestAppender appender = new TestAppender("TestAppender", null);
-    ((LoggerContext) LogManager.getContext(false)).getConfiguration().addAppender(appender);
-    ((org.apache.logging.log4j.core.Logger) logger).addAppender(appender);
-    appender.start();
-    String topicName = "topicName";
-    ProducerRecord<String, String> record = new ProducerRecord<>(topicName, 0, "key-0", "value-0");
-    TenantIdCheckInterceptor tenantIdCheckInterceptor = new TenantIdCheckInterceptor();
-
-    tenantIdCheckInterceptor.onSend(record);
-
-    Assert.assertEquals(1, appender.getMessages().size());
-    Assert.assertEquals(MessageFormatter.format(TenantIdCheckInterceptor.TENANT_ID_ERROR_MESSAGE, topicName).getMessage()
-      ,appender.getMessages().get(0));
-  }
 }

--- a/src/test/java/org/folio/kafka/interceptors/TenantIdCheckInterceptorTest.java
+++ b/src/test/java/org/folio/kafka/interceptors/TenantIdCheckInterceptorTest.java
@@ -39,12 +39,13 @@ public class TenantIdCheckInterceptorTest {
     TestAppender appender = new TestAppender("TestAppender", null);
     ((LoggerContext) LogManager.getContext(false)).getConfiguration().addAppender(appender);
     ((org.apache.logging.log4j.core.Logger) logger).addAppender(appender);
+    appender.start();
     ProducerRecord<String, String> record = new ProducerRecord<>("topicName", 0, "key-0", "value-0");
     TenantIdCheckInterceptor tenantIdCheckInterceptor = new TenantIdCheckInterceptor();
 
     tenantIdCheckInterceptor.onSend(record);
 
     Assert.assertEquals(1, appender.getMessages().size());
-    Assert.assertEquals(TenantIdCheckInterceptor.TENANT_ID_ERROR_MESSAGE, appender.getMessages().get(0));
+    Assert.assertEquals(TenantIdCheckInterceptor.TENANT_ID_ERROR_MESSAGE + record.topic(), appender.getMessages().get(0));
   }
 }

--- a/src/test/java/org/folio/kafka/interceptors/TenantIdCheckInterceptorTest.java
+++ b/src/test/java/org/folio/kafka/interceptors/TenantIdCheckInterceptorTest.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.helpers.MessageFormatter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,12 +41,14 @@ public class TenantIdCheckInterceptorTest {
     ((LoggerContext) LogManager.getContext(false)).getConfiguration().addAppender(appender);
     ((org.apache.logging.log4j.core.Logger) logger).addAppender(appender);
     appender.start();
-    ProducerRecord<String, String> record = new ProducerRecord<>("topicName", 0, "key-0", "value-0");
+    String topicName = "topicName";
+    ProducerRecord<String, String> record = new ProducerRecord<>(topicName, 0, "key-0", "value-0");
     TenantIdCheckInterceptor tenantIdCheckInterceptor = new TenantIdCheckInterceptor();
 
     tenantIdCheckInterceptor.onSend(record);
 
     Assert.assertEquals(1, appender.getMessages().size());
-    Assert.assertEquals(TenantIdCheckInterceptor.TENANT_ID_ERROR_MESSAGE + record.topic(), appender.getMessages().get(0));
+    Assert.assertEquals(MessageFormatter.format(TenantIdCheckInterceptor.TENANT_ID_ERROR_MESSAGE, topicName).getMessage()
+      ,appender.getMessages().get(0));
   }
 }

--- a/src/test/java/org/folio/kafka/interceptors/TenantIdCheckInterceptorTest.java
+++ b/src/test/java/org/folio/kafka/interceptors/TenantIdCheckInterceptorTest.java
@@ -1,0 +1,50 @@
+package org.folio.kafka.interceptors;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TenantIdCheckInterceptorTest {
+
+  private static class TestAppender extends AbstractAppender {
+
+    private final List<String> messages = new ArrayList<>();
+
+    TestAppender(String name, org.apache.logging.log4j.core.Filter filter) {
+      super(name, filter, null);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      messages.add(event.getMessage().getFormattedMessage());
+    }
+
+    List<String> getMessages() {
+      return messages;
+    }
+  }
+
+  @Test
+  public void onSend() {
+    // get logger belonging to the class and add test appender
+    Logger logger = LogManager.getLogger(TenantIdCheckInterceptor.class.getName());
+    TestAppender appender = new TestAppender("TestAppender", null);
+    ((LoggerContext) LogManager.getContext(false)).getConfiguration().addAppender(appender);
+    ((org.apache.logging.log4j.core.Logger) logger).addAppender(appender);
+    ProducerRecord<String, String> record = new ProducerRecord<>("topicName", 0, "key-0", "value-0");
+    TenantIdCheckInterceptor tenantIdCheckInterceptor = new TenantIdCheckInterceptor();
+
+    tenantIdCheckInterceptor.onSend(record);
+
+    Assert.assertEquals(1, appender.getMessages().size());
+    Assert.assertEquals(TenantIdCheckInterceptor.TENANT_ID_ERROR_MESSAGE, appender.getMessages().get(0));
+  }
+}


### PR DESCRIPTION
## Purpose
Ensure that tenant identifier is included in every message produced to Kafka.

## Approach
* Alter the KafkaProducerRecordBuilder to require a tenant id
* Add a producer interceptor to log errors when a Kafka record does not have appropriate identifier. This is for cases where message production is done directly with the Vertx Kafka client.

In addition, the version of this library has been elevated to a breaking change. This is also in preparation for other changes in regards to [Kafka Tenant Collection Topics](https://github.com/folio-org/rfcs/blob/master/text/0002-kafka-tenant-collection-topics.md)
