### PR TITLE
KAFKAWRAP-41 add tenant collection topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,61 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 
 ## Introduction
 
-Utilities for data import modules interaction with Kafka 
+Utilities for data import modules interaction with Kafka
+
+## Usage
+Creating A Configuration
+```java
+KafkaConfig kafkaConfig = KafkaConfig.builder()
+      .envId(envId)
+      .kafkaHost(kafkaHost)
+      .kafkaPort(kafkaPort)
+      .okapiUrl(okapiUrl)
+      .replicationFactor(replicationFactor)
+      .maxRequestSize(maxRequestSize)
+      .build();
+```
+
+Creating A Producer
+```java
+var producerManager = new SimpleKafkaProducerManager(vertxContext.owner(), kafkaConfig);
+var producer = producerManager.createShared(kafkaTopic);
+```
+Creating A Record
+```java
+var record = new KafkaProducerRecordBuilder<String, Object>("tenantId")
+      .key(key)
+      .value(value)
+      .topic(kafkaTopic)
+      .propagateOkapiHeaders(okapiHeaders)
+      .build();
+```
+Producing a Record
+```java
+producer.send(record)
+        .onFailure(error -> {
+          log.error("Unable to send event [{}]", producerRecord.value(), error);
+          failureHandler.handleFailure(error, producerRecord);
+        });
+```
+Consuming a Record
+```java
+KafkaConsumerWrapper<String, String> consumerWrapper = KafkaConsumerWrapper.<String, String>builder()
+        .context(context)
+        .vertx(vertx)
+        .kafkaConfig(kafkaConfig)
+        .loadLimit(loadLimit)
+        .globalLoadSensor(globalLoadSensor)
+        .subscriptionDefinition(subscriptionDefinition)
+        .processRecordErrorHandler(getErrorHandler())
+        .backPressureGauge(getBackPressureGauge())
+        .build();
+consumerWrapper.start(getHandler(), "mod-business-logic-1.2.4");
+```
+## Environment Variables
+* **KAFKA_PRODUCER_TENANT_COLLECTION**: Set to a value matching [A-Z][A-Z0-9]{0,30} .
+This will enable messages to be produced to a tenant collection topic with the "tenantId"
+set to the value of this environment variable.
 
 ## Additional information
 

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,6 @@
         <executions>
           <execution>
             <id>attach-sources</id>
-            <phase>deploy</phase>
             <goals>
               <goal>jar-no-fork</goal>
             </goals>

--- a/src/test/java/org/folio/kafka/KafkaTopicNameHelperTest.java
+++ b/src/test/java/org/folio/kafka/KafkaTopicNameHelperTest.java
@@ -1,14 +1,23 @@
 package org.folio.kafka;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.regex.Pattern;
 
+import org.junit.After;
 import org.junit.Test;
 
 public class KafkaTopicNameHelperTest {
+
+  @After
+  public void tearDown(){
+    // revert qualifier since KafkaTopicNameHelper is static and can affect other tests
+    KafkaTopicNameHelper.setTenantCollectionTopicsQualifier(null);
+  }
 
   @Test
   public void shouldFormatSubscriptionPatternForTenantAnySymbolWithAnyLength() {
@@ -58,5 +67,23 @@ public class KafkaTopicNameHelperTest {
     String topicName = KafkaTopicNameHelper.formatTopicName("folio", "Default", "test","DI_COMPLETED");
     assertNotNull(topicName);
     assertEquals("folio.Default.test.DI_COMPLETED", topicName);
+
+    // enable tenant collection topics
+    KafkaTopicNameHelper.setTenantCollectionTopicsQualifier("COLLECTION");
+    topicName = KafkaTopicNameHelper.formatTopicName("folio", "Default", "test","DI_COMPLETED");
+    assertNotNull(topicName);
+    assertEquals("folio.Default.COLLECTION.DI_COMPLETED", topicName);
+  }
+
+  @Test
+  public void isTenantCollectionEnabled(){
+    assertFalse(KafkaTopicNameHelper.isTenantCollectionTopicsEnabled());
+    KafkaTopicNameHelper.setTenantCollectionTopicsQualifier("COLLECTION");
+    assertTrue(KafkaTopicNameHelper.isTenantCollectionTopicsEnabled());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void shouldErrorWhenBadTenantCollectionQualifier() {
+      KafkaTopicNameHelper.setTenantCollectionTopicsQualifier("diku");
   }
 }


### PR DESCRIPTION
## Purpose
Add the ability to produce messages to tenant collection topics. All messages for an event type is sent to one topic instead of multiple. This is configurable through an environment variable.

## Approach
Alter the behavior of the topic name generator to return tenant collection topic names when configured by environment variable.

