### PR TITLE
KAFKAWRAP-39: Upgrade folio-kafka-wrapper to Java 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildMvn {
   mvnDeploy = 'yes'
-  buildNode = 'jenkins-agent-java11'
+  buildNode = 'jenkins-agent-java17'
 }

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2023-XX-XX v3.0.0-SNAPSHOT
+* [KAFKAWRAP-39](https://issues.folio.org/browse/KAFKAWRAP-39) Upgrade folio-kafka-wrapper to Java 17
+
 ## 2023-03-02 v2.7.0
 * [MODDATAIMP-750](https://issues.folio.org/browse/MODDATAIMP-750) Update util dependencies
 * [MODDATAIMP-736](https://issues.folio.org/browse/MODDATAIMP-736) Adjust logging configuration to display datetime in a proper format

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.10.1</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
           <encoding>UTF-8</encoding>
           <annotationProcessors>
             <annotationProcessor>lombok.launch.AnnotationProcessorHider$AnnotationProcessor</annotationProcessor>


### PR DESCRIPTION
## Purpose
_Migrate to Java 17._

## Approach

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.

## Learning
