### PR TITLE
KAFKAWRAP-46 Consider Global Load Sensor When Threshold Exceeded

### DIFF
--- a/src/main/java/org/folio/kafka/GlobalLoadSensor.java
+++ b/src/main/java/org/folio/kafka/GlobalLoadSensor.java
@@ -8,7 +8,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 
 public class GlobalLoadSensor {
-  private final AtomicInteger index = new AtomicInteger();
+  private AtomicInteger index;
+
+  public GlobalLoadSensor() {
+    index = new AtomicInteger();
+  }
+
+  protected GlobalLoadSensor(int size) {
+    index = new AtomicInteger(size);
+  }
 
   public int increment() {
     return index.incrementAndGet();
@@ -20,6 +28,24 @@ public class GlobalLoadSensor {
 
   public int current() {
     return index.get();
+  }
+
+
+  public static class GlobalLoadSensorNA extends GlobalLoadSensor {
+    @Override
+    public int increment() {
+      return -1;
+    }
+
+    @Override
+    public int decrement() {
+      return -1;
+    }
+
+    @Override
+    public int current() {
+      return -1;
+    }
   }
 
 }

--- a/src/test/java/org/folio/kafka/KafkaConsumerWrapperTest.java
+++ b/src/test/java/org/folio/kafka/KafkaConsumerWrapperTest.java
@@ -73,6 +73,31 @@ public class KafkaConsumerWrapperTest {
 
   @Test
   public void shouldResumeConsumerAndPollRecordAfterConsumerWasPaused(TestContext testContext) {
+    resumeConsumerAndPollRecordAfterConsumerWasPaused(testContext, new GlobalLoadSensor(), null);
+  }
+
+  /**
+   * When the backpressure gauge takes the global load into account, the consumer should resume
+   * after the global load is minimized.
+   */
+  @Test
+  public void shouldResumeConsumerAndPollRecordAfterConsumerWasPausedGlobalSensor(TestContext testContext) {
+    int globalLoadLimit = 7;
+    GlobalLoadSensor globalLoadSensor = new GlobalLoadSensor(globalLoadLimit);
+    BackPressureGauge<Integer, Integer, Integer> backPressureGauge = (g, l, t) -> (l > 0 && l > t) || (g > globalLoadLimit);
+    resumeConsumerAndPollRecordAfterConsumerWasPaused(testContext, globalLoadSensor, backPressureGauge)
+      .onComplete(ar -> {
+        vertx.setTimer(6000, (l) -> {
+          for (int i = 0; i < globalLoadLimit; i++) {
+            globalLoadSensor.decrement();
+          }
+        });
+      });
+  }
+
+  private Future<Void> resumeConsumerAndPollRecordAfterConsumerWasPaused(TestContext testContext,
+                                                                         GlobalLoadSensor globalLoadSensor,
+                                                                         BackPressureGauge<Integer, Integer, Integer> backPressureGauge) {
     Async async = testContext.async();
     int loadLimit = 5;
     int recordsAmountToSend = 7;
@@ -80,14 +105,15 @@ public class KafkaConsumerWrapperTest {
     System.setProperty(KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG, "2");
 
     SubscriptionDefinition subscriptionDefinition = KafkaTopicNameHelper.createSubscriptionDefinition(KAFKA_ENV, getDefaultNameSpace(), eventType());
-    KafkaConsumerWrapper<String, String> kafkaConsumerWrapper = KafkaConsumerWrapper.<String, String>builder()
+    KafkaConsumerWrapper.KafkaConsumerWrapperBuilder<String, String> kafkaConsumerWrapperBuilder = KafkaConsumerWrapper.<String, String>builder()
       .context(vertx.getOrCreateContext())
       .vertx(vertx)
       .kafkaConfig(kafkaConfig)
       .loadLimit(loadLimit)
-      .globalLoadSensor(new GlobalLoadSensor())
-      .subscriptionDefinition(subscriptionDefinition)
-      .build();
+      .globalLoadSensor(globalLoadSensor)
+      .subscriptionDefinition(subscriptionDefinition);
+    if(backPressureGauge != null) kafkaConsumerWrapperBuilder.backPressureGauge(backPressureGauge);
+    KafkaConsumerWrapper<String, String> kafkaConsumerWrapper = kafkaConsumerWrapperBuilder.build();
 
     String topicName = KafkaTopicNameHelper.formatTopicName(KAFKA_ENV, getDefaultNameSpace(), TENANT_ID, eventType());
     List<Promise<String>> promises = new ArrayList<>();
@@ -110,7 +136,7 @@ public class KafkaConsumerWrapperTest {
       }
     }, MODULE_NAME);
 
-    startFuture.onComplete(v -> {
+    return startFuture.onComplete(v -> {
       for (int i = 1; i <= recordsAmountToSend; i++) {
         sendRecord(String.valueOf(i), format("test_payload-%s", i), topicName, testContext);
       }


### PR DESCRIPTION
## Purpose
When a back pressure gauge is set to consider global load, flow control is degraded. This change aims to maintain flow control even when global load is considered.

## Approach
When a global load sensor is considered in back pressure gauge, folio-kafka-wrapper behaves inaccurately. A primary reason is that "pause requests" logic is scoped to local interactions only, without a global scope in consideration. Pause requests allow repeated resumption and pausation of the kafka consumer. Pause request counter end up being less than zero. With strict logic to only pause and resume the kafka consumer when the counter is zero never works as intended. 

Pause request logic has been replaced with a flag to determine if the kafka consumer is already paused. Also added a periodic check to ensure that the kafka consumer will be resumed eventually if there are mismatches of entry/exit procedures that cause an imbalance in counters.

## Learning
https://issues.folio.org/browse/KAFKAWRAP-46
