### PR TITLE
MODINVSTOR-1076 - Add X-Okapi-Token header to kafka record headers

### DIFF
--- a/src/main/java/org/folio/kafka/services/KafkaProducerRecordBuilder.java
+++ b/src/main/java/org/folio/kafka/services/KafkaProducerRecordBuilder.java
@@ -12,10 +12,12 @@ import java.util.Set;
 import static io.vertx.kafka.client.producer.KafkaProducerRecord.create;
 import static java.util.Objects.isNull;
 import static org.folio.okapi.common.XOkapiHeaders.TENANT;
+import static org.folio.okapi.common.XOkapiHeaders.TOKEN;
 import static org.folio.okapi.common.XOkapiHeaders.URL;
 
 public final class KafkaProducerRecordBuilder<K, V> {
-  private static final Set<String> FORWARDER_HEADERS = Set.of(URL.toLowerCase(), TENANT.toLowerCase());
+  private static final Set<String> FORWARDER_HEADERS =
+    Set.of(URL.toLowerCase(), TENANT.toLowerCase(), TOKEN.toLowerCase());
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private V value;

--- a/src/test/java/org/folio/kafka/SimpleKafkaProducerManagerTest.java
+++ b/src/test/java/org/folio/kafka/SimpleKafkaProducerManagerTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import static java.util.UUID.randomUUID;
 import static org.folio.kafka.services.TestKafkaTopic.TOPIC_ONE;
 import static org.folio.okapi.common.XOkapiHeaders.TENANT;
+import static org.folio.okapi.common.XOkapiHeaders.TOKEN;
 import static org.folio.okapi.common.XOkapiHeaders.URL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -49,14 +50,15 @@ public class SimpleKafkaProducerManagerTest {
     Map<String, String> okapiHeaders = Map.of(
       URL.toLowerCase(), "1",
       TENANT.toLowerCase(), "2",
-      "not-okapi", "3");
+      TOKEN.toLowerCase(), "3",
+      "not-okapi", "4");
 
     var producerRecord = new KafkaProducerRecordBuilder<String, String>()
       .propagateOkapiHeaders(okapiHeaders)
       .value(TOPIC_ONE.topicName())
       .build();
 
-    assertEquals(2, producerRecord.headers().size());
+    assertEquals(3, producerRecord.headers().size());
   }
 
   @Test(expected = ProducerCreationException.class)

--- a/src/test/java/org/folio/kafka/SimpleKafkaProducerManagerTest.java
+++ b/src/test/java/org/folio/kafka/SimpleKafkaProducerManagerTest.java
@@ -66,7 +66,7 @@ public class SimpleKafkaProducerManagerTest {
       .value(TOPIC_ONE.topicName())
       .build();
 
-    assertEquals(5, producerRecord.headers().size());
+    assertEquals(6, producerRecord.headers().size());
   }
 
   @Test(expected = ProducerCreationException.class)


### PR DESCRIPTION
## Purpose
MODINVSTOR-1076 implementation needs "X-Okapi-Token" header to be placed into kafka message headers for making http requests to mod-consortia during processing of event about instance update


## Learning
[MODINVSTOR-1076](https://issues.folio.org/browse/MODINVSTOR-1076)