### PR TITLE
KAFKAWRAP-47 Extend KafkaTopicNameHelper to have formatTopicName

### DIFF
--- a/src/main/java/org/folio/kafka/KafkaTopicNameHelper.java
+++ b/src/main/java/org/folio/kafka/KafkaTopicNameHelper.java
@@ -45,6 +45,14 @@ public class KafkaTopicNameHelper {
     return join(".", env, nameSpace, tenantId, eventType);
   }
 
+  public static String formatTopicName(String env, String tenant, String eventType) {
+    String tenantId = tenant;
+    if (TENANT_COLLECTION_TOPICS_ENABLED) {
+      tenantId = TENANT_COLLECTION_TOPIC_QUALIFIER;
+    }
+    return join(".", env, tenantId, eventType);
+  }
+
   public static String getEventTypeFromTopicName(String topic) {
     int eventTypeIndex = StringUtils.isBlank(topic) ? -1 : topic.lastIndexOf('.') + 1;
     if (eventTypeIndex > 0) {

--- a/src/main/java/org/folio/kafka/services/KafkaTopic.java
+++ b/src/main/java/org/folio/kafka/services/KafkaTopic.java
@@ -30,7 +30,7 @@ public interface KafkaTopic {
    * Returns replication factor.
    * Default - environment variable 'REPLICATION_FACTOR'
    */
-  default short replicationFactor(){
+  default short replicationFactor() {
     return KafkaEnvironmentProperties.replicationFactor();
   }
 
@@ -47,7 +47,7 @@ public interface KafkaTopic {
    * Order: {environment}.{tenantId}.{modulePrefix}.{topicName}
    */
   default String fullTopicName(String tenant) {
-    return formatTopicName(environment(), tenant, moduleName(), topicName());
+    return formatTopicName(environment(), tenant, join(".", moduleName(), topicName()));
   }
 
   /**
@@ -55,6 +55,6 @@ public interface KafkaTopic {
    * Order: {environment}.{tenantId}.{modulePrefix}.{topicName}
    */
   default String fullTopicName(KafkaConfig config, String tenant) {
-    return formatTopicName(config.getEnvId(), tenant, moduleName(), topicName());
+    return formatTopicName(environment(), tenant, join(".", moduleName(), topicName()));
   }
 }

--- a/src/test/java/org/folio/kafka/KafkaTopicNameHelperTest.java
+++ b/src/test/java/org/folio/kafka/KafkaTopicNameHelperTest.java
@@ -76,6 +76,24 @@ public class KafkaTopicNameHelperTest {
   }
 
   @Test
+  public void shouldFormatTopicNameWithoutNamespace() {
+    String topicName = KafkaTopicNameHelper.formatTopicName("folio", "test","DI_COMPLETED");
+    assertNotNull(topicName);
+    assertEquals("folio.test.DI_COMPLETED", topicName);
+
+    // enable tenant collection topics
+    KafkaTopicNameHelper.setTenantCollectionTopicsQualifier("COLLECTION");
+    topicName = KafkaTopicNameHelper.formatTopicName("folio", "test","DI_COMPLETED");
+    assertNotNull(topicName);
+    assertEquals("folio.COLLECTION.DI_COMPLETED", topicName);
+  }
+
+  @Test
+  public void getDefaultNamespace() {
+    assertEquals("Default", KafkaTopicNameHelper.getDefaultNameSpace());
+  }
+
+  @Test
   public void isTenantCollectionEnabled(){
     assertFalse(KafkaTopicNameHelper.isTenantCollectionTopicsEnabled());
     KafkaTopicNameHelper.setTenantCollectionTopicsQualifier("COLLECTION");


### PR DESCRIPTION
## Purpose
_Need to support old topic naming approach._

## Approach
_Added  new method to KafkaTopicNameHelper without name space_

## Learning
[KAFKAWRAP-47](https://issues.folio.org/browse/KAFKAWRAP-47)
