### PR TITLE
KAFKAWRAP-50 Set consumer state to resumed when fetch() is called

### DIFF
--- a/src/main/java/org/folio/kafka/KafkaConsumerWrapper.java
+++ b/src/main/java/org/folio/kafka/KafkaConsumerWrapper.java
@@ -196,6 +196,7 @@ public class KafkaConsumerWrapper<K, V> implements Handler<KafkaConsumerRecord<K
 
   public void fetch(long amount) {
     kafkaConsumer.fetch(amount);
+    isPaused.set(false);
   }
 
   /**

--- a/src/test/java/org/folio/kafka/KafkaConsumerWrapperTest.java
+++ b/src/test/java/org/folio/kafka/KafkaConsumerWrapperTest.java
@@ -72,6 +72,28 @@ public class KafkaConsumerWrapperTest {
   }
 
   @Test
+  public void consumerInResumedModeAfterFetch(TestContext testContext) {
+    int loadLimit = 5;
+    SubscriptionDefinition subscriptionDefinition = KafkaTopicNameHelper.createSubscriptionDefinition(KAFKA_ENV, getDefaultNameSpace(), eventType());
+    KafkaConsumerWrapper<String, String> kafkaConsumerWrapper = KafkaConsumerWrapper.<String, String>builder()
+      .context(vertx.getOrCreateContext())
+      .vertx(vertx)
+      .kafkaConfig(kafkaConfig)
+      .loadLimit(loadLimit)
+      .globalLoadSensor(new GlobalLoadSensor.GlobalLoadSensorNA())
+      .subscriptionDefinition(subscriptionDefinition)
+      .build();
+
+    kafkaConsumerWrapper.start(record -> Future.succeededFuture(record.key()), MODULE_NAME);
+    testContext.assertFalse(kafkaConsumerWrapper.isConsumerPaused());
+    kafkaConsumerWrapper.pause();
+    testContext.assertTrue(kafkaConsumerWrapper.isConsumerPaused());
+    kafkaConsumerWrapper.fetch(2);
+    testContext.assertFalse(kafkaConsumerWrapper.isConsumerPaused());;
+
+  }
+
+  @Test
   public void shouldResumeConsumerAndPollRecordAfterConsumerWasPaused(TestContext testContext) {
     resumeConsumerAndPollRecordAfterConsumerWasPaused(testContext, new GlobalLoadSensor(), null);
   }


### PR DESCRIPTION
## Purpose
The fetch command on KafkaConsumerWrapper should set the state of the consumer ot resumed.

The consequence of this bug is that a command to set the fetch amount is reverted back to default value when resume() is called by the 
businessHandlerCompletionHandler method.

## Approach
Set the `isPaused` flag to false when fetch is called.

## Learning
https://issues.folio.org/browse/KAFKAWRAP-50
