### PR TITLE
KAFKAWRAP-52 Allow Consumer Deserializers to be Configured

### DIFF
--- a/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @ToString
 public class KafkaConfig {
   public static final String KAFKA_CONSUMER_AUTO_OFFSET_RESET_CONFIG = "kafka.consumer.auto.offset.reset";
@@ -83,6 +83,16 @@ public class KafkaConfig {
   private final int replicationFactor;
   private final String envId;
   private final int maxRequestSize;
+  /**
+   * Deserializer class reference that will be used for record keys in a Kafka consumer.
+   * If not set, a String deserializer is used
+   */
+  private final String consumerKeyDeserializerClass;
+  /**
+   * Deserializer class reference that will be used for record values in a Kafka consumer
+   * If not set, a String deserializer is used
+   */
+  private final String consumerValueDeserializerClass;
 
   public Map<String, String> getProducerProps() {
     Map<String, String> producerProps = new HashMap<>();
@@ -120,8 +130,10 @@ public class KafkaConfig {
     Map<String, String> consumerProps = new HashMap<>();
     consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaUrl());
     consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-    consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
-    consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+    consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+      this.getConsumerKeyDeserializerClass() != null ? this.getConsumerKeyDeserializerClass() : "org.apache.kafka.common.serialization.StringDeserializer");
+    consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+      this.getConsumerValueDeserializerClass() != null ? this.getConsumerValueDeserializerClass() : "org.apache.kafka.common.serialization.StringDeserializer");
 
     consumerProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, SimpleConfigurationReader.getValue(
       List.of(KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG, SpringKafkaProperties.KAFKA_CONSUMER_MAX_POLL_RECORDS), KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG_DEFAULT));

--- a/src/test/java/org/folio/kafka/KafkaConfigTest.java
+++ b/src/test/java/org/folio/kafka/KafkaConfigTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import java.util.Map;
 
 import static org.folio.kafka.KafkaConfig.KAFKA_NUMBER_OF_PARTITIONS;
-import static org.junit.Assert.*;
 
 public class KafkaConfigTest {
 
@@ -32,16 +31,28 @@ public class KafkaConfigTest {
       String maxPullRecordsValue = "500";
       System.setProperty(KafkaConfig.KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG, maxPullRecordsValue);
 
-      Map<String, String> consumerProps = KafkaConfig.builder()
+      KafkaConfig kafkaConfig = KafkaConfig.builder()
         .kafkaHost("127.0.0.1")
         .kafkaPort("9092")
-        .build()
-        .getConsumerProps();
+        .build();
+      Map<String, String> consumerProps = kafkaConfig.getConsumerProps();
 
       Assert.assertEquals("127.0.0.1:9092", consumerProps.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
       Assert.assertEquals(KafkaConfig.KAFKA_CONSUMER_METADATA_MAX_AGE_CONFIG_DEFAULT, consumerProps.get(ConsumerConfig.METADATA_MAX_AGE_CONFIG));
       Assert.assertEquals(KafkaConfig.KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG_DEFAULT, consumerProps.get(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG));
       Assert.assertEquals(maxPullRecordsValue, consumerProps.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG));
+      Assert.assertEquals("org.apache.kafka.common.serialization.StringDeserializer", consumerProps.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
+      Assert.assertEquals("org.apache.kafka.common.serialization.StringDeserializer", consumerProps.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
+
+      consumerProps = kafkaConfig.toBuilder()
+        .consumerKeyDeserializerClass("org.apache.kafka.common.serialization.ByteArrayDeserializer")
+        .consumerValueDeserializerClass("org.apache.kafka.common.serialization.ByteArrayDeserializer")
+        .build()
+        .getConsumerProps();
+
+      Assert.assertEquals("org.apache.kafka.common.serialization.ByteArrayDeserializer", consumerProps.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
+      Assert.assertEquals("org.apache.kafka.common.serialization.ByteArrayDeserializer", consumerProps.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
+
     }
 
     @Test


### PR DESCRIPTION
## Purpose
Allow Consumer Deserializers to be Configured

## Approach
Added properties to KafkaConfig to store custom deserializers for Kafka consumers. Also, allow the details of an existing KafkaConfig instance to be reused for a new KafkaConfig instance with deserializers set. This is because properties of KafkaConfig are final.
