### PR TITLE
MODDATAIMP-886 Create Kafka topics instead of relying on auto create

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2023-XX-XX v3.1.0-SNAPSHOT
 * [KAFKAWRAP-50](https://issues.folio.org/browse/KAFKAWRAP-50) KafkaConsumerWrapper.fetch Should Set Consumer to Resumed State
+* [MODDATAIMP-886](https://issues.folio.org/browse/MODDATAIMP-886) Create Kafka topics instead of relying on auto create
 
 ## 2023-10-11 v3.0.0
 * [KAFKAWRAP-39](https://issues.folio.org/browse/KAFKAWRAP-39) Upgrade folio-kafka-wrapper to Java 17

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ KafkaConfig kafkaConfig = KafkaConfig.builder()
       .maxRequestSize(maxRequestSize)
       .build();
 ```
-
+Creating A Topic
+```java
+KafkaAdminClientService kafkaAdminClientService = new KafkaAdminClientService(vertx);
+kafkaAdminClientService.createKafkaTopics(DataImportKafkaTopic.values(), tenantId);
+```
 Creating A Producer
 ```java
 var producerManager = new SimpleKafkaProducerManager(vertxContext.owner(), kafkaConfig);


### PR DESCRIPTION
## Purpose
Create Kafka topics instead of relying on auto create [MODDATAIMP-886](https://issues.folio.org/browse/MODDATAIMP-886)

## Approach
update docs