### PR TITLE
KAFKAWRAP-54 Do not delete kafka topics if collection topic is enabled

### DIFF
--- a/src/main/java/org/folio/kafka/services/KafkaAdminClientService.java
+++ b/src/main/java/org/folio/kafka/services/KafkaAdminClientService.java
@@ -15,6 +15,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.folio.kafka.KafkaTopicNameHelper;
 
 import static io.vertx.kafka.admin.KafkaAdminClient.create;
 import static org.apache.logging.log4j.LogManager.getLogger;
@@ -41,6 +42,9 @@ public class KafkaAdminClientService {
   }
 
   public Future<Void> deleteKafkaTopics(KafkaTopic[] enumTopics, String tenantId) {
+    if (KafkaTopicNameHelper.isTenantCollectionTopicsEnabled()) {
+      return Future.succeededFuture();
+    }
     List<String> topicsToDelete = readTopics(enumTopics, tenantId)
       .map(NewTopic::getName)
       .collect(Collectors.toList());

--- a/src/test/java/org/folio/kafka/services/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/kafka/services/KafkaAdminClientServiceTest.java
@@ -7,6 +7,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.kafka.admin.KafkaAdminClient;
 import io.vertx.kafka.admin.NewTopic;
 import org.apache.kafka.common.errors.TopicExistsException;
+import org.folio.kafka.KafkaTopicNameHelper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(VertxUnitRunner.class)
@@ -129,6 +131,17 @@ public class KafkaAdminClientServiceTest {
 
         assertTrue(allExpectedTopics.containsAll(deleteTopicsCaptor.getAllValues().get(0)));
       }));
+  }
+
+  @Test
+  public void shouldNotDeleteTopics_whenCollectionTopicIsEnabled(TestContext testContext) {
+    try (var mocked = mockStatic(KafkaTopicNameHelper.class)) {
+      mocked.when(KafkaTopicNameHelper::isTenantCollectionTopicsEnabled).thenReturn(true);
+
+      new KafkaAdminClientService(vertx)
+        .deleteKafkaTopics(TestKafkaTopic.values(), STUB_TENANT)
+        .onComplete(testContext.asyncAssertSuccess(notUsed -> verifyNoInteractions(mockClient)));
+    }
   }
 
   private List<String> getTopicNames(ArgumentCaptor<List<NewTopic>> createTopicsCaptor) {


### PR DESCRIPTION
## Purpose
Do not delete Kafka topics if the collection topic is enabled

## Approach
Check if collection topic feature is enabled 
