### PR TITLE
KAFKAWRAP-58: Add possibility to specify retention time and max massage size topic configs

### DIFF
--- a/src/main/java/org/folio/kafka/services/KafkaTopic.java
+++ b/src/main/java/org/folio/kafka/services/KafkaTopic.java
@@ -57,4 +57,24 @@ public interface KafkaTopic {
   default String fullTopicName(KafkaConfig config, String tenant) {
     return formatTopicName(environment(), tenant, join(".", moduleName(), topicName()));
   }
+
+  /**
+   * Returns retention time in milliseconds for this topic's messages.
+   *
+   * @return {@link Integer} type value for a message's retention in milliseconds.
+   * if value is null then it means to use default value for this config
+   */
+  default Integer messageRetentionTime() {
+    return null;
+  }
+
+  /**
+   * Returns message's max size in bytes.
+   *
+   * @return {@link Integer} type value of message's max size in bytes.
+   * if value is null then it means to use default value for this config
+   */
+  default Integer messageMaxSize() {
+    return null;
+  }
 }

--- a/src/test/java/org/folio/kafka/services/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/kafka/services/KafkaAdminClientServiceTest.java
@@ -21,6 +21,7 @@ import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -113,6 +114,16 @@ public class KafkaAdminClientServiceTest {
 
         // Only these items are expected, so implicitly checks size of list
         assertTrue(allExpectedTopics.containsAll(getTopicNames(createTopicsCaptor)));
+
+        var topicWithConfigs = createTopicsCaptor.getAllValues().get(0).stream()
+          .filter(topic -> topic.getConfig() != null)
+          .filter(topic -> Boolean.FALSE.equals(topic.getConfig().isEmpty()))
+          .findFirst();
+        assertTrue(topicWithConfigs.isPresent());
+        assertEquals("1000",
+          topicWithConfigs.get().getConfig().get(KafkaAdminClientService.MESSAGE_RETENTION_TIME_IN_MILLIS_CONFIG));
+        assertEquals("2000",
+          topicWithConfigs.get().getConfig().get(KafkaAdminClientService.MESSAGE_MAX_SIZE_IN_BYTES_CONFIG));
       }));
   }
 

--- a/src/test/java/org/folio/kafka/services/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/kafka/services/KafkaAdminClientServiceTest.java
@@ -15,7 +15,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
@@ -37,13 +36,14 @@ import static org.mockito.Mockito.when;
 @RunWith(VertxUnitRunner.class)
 public class KafkaAdminClientServiceTest {
 
+  private static final String STUB_TENANT = "foo-tenant";
+
   private final List<String> allExpectedTopics = List.of(
     "folio.foo-tenant.kafka-wrapper.topic1",
     "folio.foo-tenant.kafka-wrapper.topic2",
     "folio.foo-tenant.kafka-wrapper.topic3"
   );
 
-  private final String STUB_TENANT = "foo-tenant";
   private KafkaAdminClient mockClient;
   private Vertx vertx;
 
@@ -120,9 +120,9 @@ public class KafkaAdminClientServiceTest {
           .filter(topic -> Boolean.FALSE.equals(topic.getConfig().isEmpty()))
           .findFirst();
         assertTrue(topicWithConfigs.isPresent());
-        assertEquals("1000",
+        assertEquals(TestKafkaTopic.TOPIC_THREE.messageRetentionTime() + "",
           topicWithConfigs.get().getConfig().get(KafkaAdminClientService.MESSAGE_RETENTION_TIME_IN_MILLIS_CONFIG));
-        assertEquals("2000",
+        assertEquals(TestKafkaTopic.TOPIC_THREE.messageMaxSize() + "",
           topicWithConfigs.get().getConfig().get(KafkaAdminClientService.MESSAGE_MAX_SIZE_IN_BYTES_CONFIG));
       }));
   }
@@ -158,7 +158,7 @@ public class KafkaAdminClientServiceTest {
   private List<String> getTopicNames(ArgumentCaptor<List<NewTopic>> createTopicsCaptor) {
     return createTopicsCaptor.getAllValues().get(0).stream()
       .map(NewTopic::getName)
-      .collect(Collectors.toList());
+      .toList();
   }
 
   private Future<Void> createKafkaTopicsAsync(KafkaAdminClient client) {

--- a/src/test/java/org/folio/kafka/services/TestKafkaTopic.java
+++ b/src/test/java/org/folio/kafka/services/TestKafkaTopic.java
@@ -20,4 +20,22 @@ public enum TestKafkaTopic implements KafkaTopic {
   public String topicName() {
     return topic;
   }
+
+  @Override
+  public Integer messageRetentionTime() {
+    if (this == TOPIC_THREE) {
+      return 1000;
+    }
+    return null;
+  }
+
+  @Override
+  public Integer messageMaxSize() {
+    if (this == TOPIC_THREE) {
+      return 2000;
+    }
+    return null;
+  }
+
+
 }


### PR DESCRIPTION
## Purpose
_Extends KafkaTopic interface with possibility to specify retention time (in milliseconds) and max message size (in bytes)_

## Approach
_add new methods into KafkaTopic interface_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
- [x] Unit testing

## Learning
[KAFKAWRAP-58](https://folio-org.atlassian.net/browse/KAFKAWRAP-58)
