### PR TITLE
KAFKAWRAP-66 - Expose config parameters for "group.instance.id" and "session.timeout.ms" properties

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2025-xx-xx 3.4.0-SNAPSHOT
+* [KAFKAWRAP-66](https://issues.folio.org/browse/KAFKAWRAP-66) Provide parameters for configuring group.instance.id and session timeout
+
 ## 2025-03-07 v3.3.0
 * [KAFKAWRAP-61](https://folio-org.atlassian.net/browse/KAFKAWRAP-61) Update to folio-kafka-wrapper-util Java 21
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,36 @@ KafkaConsumerWrapper<String, String> consumerWrapper = KafkaConsumerWrapper.<Str
         .build();
 consumerWrapper.start(getHandler(), "mod-business-logic-1.2.4");
 ```
+
+Creating consumer wrapper over static consumer (when [group.instance.id](https://kafka.apache.org/documentation/#consumerconfigs_group.instance.id) is set)  
+Declaring static consumer using builder method:
+```java
+KafkaConsumerWrapper<String, String> consumerWrapper = KafkaConsumerWrapper.<String, String>builder()
+        .context(context)
+        .vertx(vertx)
+        .kafkaConfig(kafkaConfig)
+        .loadLimit(loadLimit)
+        .globalLoadSensor(globalLoadSensor)
+        .subscriptionDefinition(subscriptionDefinition)
+        .processRecordErrorHandler(getErrorHandler())
+        .backPressureGauge(getBackPressureGauge())
+        .groupInstanceId(groupInstanceId)
+        .build();
+```
+Declaring static consumer using setter:
+```java
+KafkaConsumerWrapper<String, String> consumerWrapper = KafkaConsumerWrapper.<String, String>builder()
+        .context(context)
+        .vertx(vertx)
+        .kafkaConfig(kafkaConfig)
+        .loadLimit(loadLimit)
+        .globalLoadSensor(globalLoadSensor)
+        .subscriptionDefinition(subscriptionDefinition)
+        .processRecordErrorHandler(getErrorHandler())
+        .backPressureGauge(getBackPressureGauge())
+        .build();
+consumerWrapper.setGroupInstanceId(groupInstanceId);
+```
 ## Environment Variables
 * **KAFKA_PRODUCER_TENANT_COLLECTION**: Set to a value matching [A-Z][A-Z0-9]{0,30} .
 This will enable messages to be produced to a tenant collection topic with the "tenantId"

--- a/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -32,6 +32,12 @@ public class KafkaConfig {
   public static final String KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG = "kafka.consumer.max.poll.interval.ms";
   public static final String KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG_DEFAULT = "600000";
 
+  public static final String KAFKA_CONSUMER_SESSION_TIMOUT_MS_CONFIG = "kafka.consumer.session.timeout.ms";
+  public static final String KAFKA_CONSUMER_SESSION_TIMOUT_MS_CONFIG_DEFAULT = "45000";
+
+  public static final String KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG = "kafka.consumer.heartbeat.interval.ms";
+  public static final String KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG_DEFAULT = "3000";
+
   public static final String KAFKA_PRODUCER_COMPRESSION_TYPE_CONFIG = "kafka.producer.compression.type";
   public static final String KAFKA_PRODUCER_COMPRESSION_TYPE_CONFIG_DEFAULT = "gzip";
 
@@ -143,6 +149,10 @@ public class KafkaConfig {
       List.of(KAFKA_CONSUMER_AUTO_OFFSET_RESET_CONFIG, SpringKafkaProperties.KAFKA_CONSUMER_AUTO_OFFSET_RESET), KAFKA_CONSUMER_AUTO_OFFSET_RESET_CONFIG_DEFAULT));
     consumerProps.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, SimpleConfigurationReader.getValue(
       List.of(KAFKA_CONSUMER_METADATA_MAX_AGE_CONFIG, SpringKafkaProperties.KAFKA_CONSUMER_METADATA_MAX_AGE), KAFKA_CONSUMER_METADATA_MAX_AGE_CONFIG_DEFAULT));
+    consumerProps.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_CONSUMER_SESSION_TIMOUT_MS_CONFIG, SpringKafkaProperties.KAFKA_CONSUMER_SESSION_TIMEOUT_MS), KAFKA_CONSUMER_SESSION_TIMOUT_MS_CONFIG_DEFAULT));
+    consumerProps.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG, SpringKafkaProperties.KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG), KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG_DEFAULT));
     ensureSecurityProps(consumerProps);
     return consumerProps;
   }

--- a/src/main/java/org/folio/kafka/KafkaConsumerWrapper.java
+++ b/src/main/java/org/folio/kafka/KafkaConsumerWrapper.java
@@ -76,6 +76,10 @@ public class KafkaConsumerWrapper<K, V> implements Handler<KafkaConsumerRecord<K
     this.loadBottomGreenLine = loadLimit / 2;
   }
 
+  public void setGroupInstanceId(String groupInstanceId) {
+    this.groupInstanceId = groupInstanceId;
+  }
+
   @Builder
   private KafkaConsumerWrapper(Vertx vertx, Context context, KafkaConfig kafkaConfig, SubscriptionDefinition subscriptionDefinition, Boolean addToGlobalLoad,
                                GlobalLoadSensor globalLoadSensor, ProcessRecordErrorHandler<K, V> processRecordErrorHandler, BackPressureGauge<Integer, Integer, Integer> backPressureGauge, int loadLimit,

--- a/src/main/java/org/folio/kafka/SpringKafkaProperties.java
+++ b/src/main/java/org/folio/kafka/SpringKafkaProperties.java
@@ -10,6 +10,10 @@ public final class SpringKafkaProperties {
 
   public static final String KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS = "spring.kafka.consumer.properties.max.poll.interval.ms";
 
+  public static final String KAFKA_CONSUMER_SESSION_TIMEOUT_MS = "spring.kafka.consumer.properties.session.timeout.ms";
+
+  public static final String KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG = "spring.kafka.consumer.properties.heartbeat.interval.ms";
+
   public static final String KAFKA_SECURITY_PROTOCOL = "spring.kafka.security.protocol";
 
   public static final String KAFKA_PRODUCER_COMPRESSION_TYPE = "spring.kafka.producer.compression-type";


### PR DESCRIPTION
## Purpose
to provide the ability to set up "group.instance.id" consumer property for configuring a static consumer, which in turn can reduce rebalancing time. Additionally, to expose "session.timeout.ms" parameter (and "heartbeat.interval.ms") that can affect rebalancing frequency.



## Learning
[KAFKAWRAP-66](https://issues.folio.org/browse/KAFKAWRAP-66)