### PR TITLE
KAFKAWRAP-73 Update kafka to 4.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## xxxx-xx-xx vx.x.x
+* [KAFKAWRAP-73](https://issues.folio.org/browse/KAFKAWRAP-73) Upgrade Vert.x to 5.0.12 to use Kafka 4.2
+
 ## 2026-04-10 4.0.0
 * Fix maven-javadoc-plugin version
 * [KAFKAWRAP-66](https://issues.folio.org/browse/KAFKAWRAP-66) Provide parameters for configuring group.instance.id and session timeout

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <lombok.version>1.18.42</lombok.version>
     <commons-lang3.version>3.19.0</commons-lang3.version>
     <log4j.version>2.25.2</log4j.version>
-    <vertx.version>5.0.11</vertx.version>
+    <vertx.version>5.0.12</vertx.version>
     <okapi-common.version>7.0.0</okapi-common.version>
     <testcontainers.version>1.21.3</testcontainers.version>
     <mockito.version>5.20.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <lombok.version>1.18.42</lombok.version>
     <commons-lang3.version>3.19.0</commons-lang3.version>
     <log4j.version>2.25.2</log4j.version>
-    <vertx.version>5.0.5</vertx.version>
+    <vertx.version>5.0.11</vertx.version>
     <okapi-common.version>7.0.0</okapi-common.version>
     <testcontainers.version>1.21.3</testcontainers.version>
     <mockito.version>5.20.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <log4j.version>2.25.2</log4j.version>
     <vertx.version>5.0.12</vertx.version>
     <okapi-common.version>7.0.0</okapi-common.version>
-    <testcontainers.version>1.21.3</testcontainers.version>
+    <testcontainers.version>2.0.4</testcontainers.version>
     <mockito.version>5.20.0</mockito.version>
   </properties>
 
@@ -115,7 +115,7 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>kafka</artifactId>
+      <artifactId>testcontainers-kafka</artifactId>
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/test/java/org/folio/kafka/KafkaConsumerWrapperTest.java
+++ b/src/test/java/org/folio/kafka/KafkaConsumerWrapperTest.java
@@ -11,6 +11,7 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -28,7 +29,7 @@ import static org.folio.okapi.common.XOkapiHeaders.REQUEST_ID;
 import static org.folio.okapi.common.XOkapiHeaders.TENANT;
 import static org.folio.okapi.common.XOkapiHeaders.USER_ID;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -42,8 +43,7 @@ public class KafkaConsumerWrapperTest {
   @Rule
   public TestName testName = new TestName();
 
-  @Rule
-  public KafkaContainer kafka = new KafkaContainer("apache/kafka-native:3.8.0")
+  public KafkaContainer kafka = new KafkaContainer("apache/kafka-native:4.2.0")
       .withStartupAttempts(3);
 
   private Vertx vertx = Vertx.vertx();
@@ -53,6 +53,8 @@ public class KafkaConsumerWrapperTest {
 
   @Before
   public void setUp() {
+    kafka.start();
+
     kafkaConfig = KafkaConfig.builder()
       .kafkaHost(kafka.getHost())
       .kafkaPort(kafka.getFirstMappedPort() + "")
@@ -72,7 +74,7 @@ public class KafkaConsumerWrapperTest {
   public void tearDown(TestContext testContext) {
     kafkaAdminClient.close()
     .onComplete(x -> producer.close())
-    .onComplete(testContext.asyncAssertSuccess());
+    .onComplete(testContext.asyncAssertSuccess(v -> kafka.stop()));
   }
 
   @Test
@@ -256,6 +258,10 @@ public class KafkaConsumerWrapperTest {
     SubscriptionDefinition subscriptionDefinition = KafkaTopicNameHelper.createSubscriptionDefinition(KAFKA_ENV, getDefaultNameSpace(), eventType());
     String topicName = KafkaTopicNameHelper.formatTopicName(KAFKA_ENV, getDefaultNameSpace(), TENANT_ID, eventType());
     ProcessRecordErrorHandler<String, String> recordErrorHandler = mock(ProcessRecordErrorHandler.class);
+    doAnswer(invocation -> {
+      async.complete();
+      return null;
+    }).when(recordErrorHandler).handle(any(Throwable.class), any(KafkaConsumerRecord.class));
 
     KafkaConsumerWrapper<String, String> kafkaConsumerWrapper = KafkaConsumerWrapper.<String, String>builder()
       .context(vertx.getOrCreateContext())
@@ -272,10 +278,10 @@ public class KafkaConsumerWrapperTest {
         return Future.failedFuture("test error msg");
       }, MODULE_NAME)
       .eventually(() -> sendRecord("1", "test_payload", topicName))
-      .onComplete(x -> async.complete());
+      .onComplete(testContext.asyncAssertSuccess());
 
     async.await();
-    verify(recordErrorHandler, after(500)).handle(any(Throwable.class), any(KafkaConsumerRecord.class));
+    verify(recordErrorHandler).handle(any(Throwable.class), any(KafkaConsumerRecord.class));
   }
 
   @Test
@@ -329,6 +335,23 @@ public class KafkaConsumerWrapperTest {
             return Future.succeededFuture();
           }
           return awaitMembersSize(groupId, expectedSize);
+        })
+        .recover(t -> {
+          if (isGroupNotFoundError(t)) {
+            return expectedSize == 0 ? Future.succeededFuture() : awaitMembersSize(groupId, expectedSize);
+          }
+          return Future.failedFuture(t);
         });
+  }
+
+  private boolean isGroupNotFoundError(Throwable throwable) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (current instanceof GroupIdNotFoundException) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
   }
 }


### PR DESCRIPTION
## Purpose
Update the required dependencies to enable support for Kafka 4.2 and ensure compatibility with the newer Kafka version

## Approach
- Upgrade testContainers and kafka-native image for tests
- In src/test/java/org/folio/kafka/KafkaConsumerWrapperTest.java, the helper awaitMembersSize(...) was updated to handle GroupIdNotFoundException in a .recover(...) branch (via isGroupNotFoundError(...) that walks the cause chain).

What the fix does
- Before: awaitMembersSize(groupId, expectedSize) assumed describeConsumerGroups always returned a map entry for groupId.
- After upgrade: Kafka Admin can fail the call with GroupIdNotFoundException when the group does not exist yet (or no longer exists), instead of returning a “group with 0 members” style result.

New logic:
- If error is GroupIdNotFoundException and expectedSize == 0 → treat as success.
- If error is GroupIdNotFoundException and expectedSize > 0 → retry by recursively calling awaitMembersSize(...).
- Any other exception → fail fast (Future.failedFuture(t)).